### PR TITLE
reformat dir structure of graph and graph manager

### DIFF
--- a/scheduling/flow/costmodel/interface.go
+++ b/scheduling/flow/costmodel/interface.go
@@ -20,7 +20,7 @@ package costmodel
 import (
 	"github.com/coreos/ksched/pkg/types"
 	pb "github.com/coreos/ksched/proto"
-	"github.com/coreos/ksched/scheduling/flow/cluster"
+	"github.com/coreos/ksched/scheduling/flow/flowgraph"
 )
 
 type (
@@ -109,14 +109,14 @@ type CostModeler interface {
 
 	// Gathers statistics during reverse traversal of resource topology (from
 	// sink upwards). Called on pairs of connected nodes.
-	GatherStats(accumulator, other *cluster.FlowGraphNode)
+	GatherStats(accumulator, other *flowgraph.Node)
 
 	// The default Prepare action is a no-op. Cost models can override this if
 	// they need to perform preparation actions before GatherStats is invoked.
-	PrepareStats(accumulator *cluster.FlowGraphNode)
+	PrepareStats(accumulator *flowgraph.Node)
 
 	// Generates updates for arc costs in the resource topology.
-	UpdateStats(accumulator, other *cluster.FlowGraphNode) *cluster.FlowGraphNode
+	UpdateStats(accumulator, other *flowgraph.Node) *flowgraph.Node
 
 	// Handle to pull debug information from cost model; return string.
 	DebugInfo() string

--- a/scheduling/flow/flowgraph/arc.go
+++ b/scheduling/flow/flowgraph/arc.go
@@ -12,32 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Represents an arc in the scheduling flow graph.
-// C++ file: https://github.com/camsas/firmament/blob/master/src/scheduling/flow/flow_graph_arc.h
-package cluster
+package flowgraph
 
 //Enum for flow arc type
-type FlowArcType int
+type ArcType int
 
 const (
-	Other FlowNodeType = iota + 1
+	Other NodeType = iota + 1
 	Running
 )
 
-type FlowGraphArc struct {
+// Represents an arc in the scheduling flow graph.
+type Arc struct {
 	src           uint64
 	dst           uint64
 	capLowerBound uint64
 	capUpperBound uint64
 	cost          int64
-	srcNode       *FlowGraphNode
-	dstNode       *FlowGraphNode
-	typ           FlowArcType
+	srcNode       *Node
+	dstNode       *Node
+	typ           ArcType
 }
 
 // Constructor equivalent in go
-func NewArc(srcID, dstID uint64, srcNode, dstNode *FlowGraphNode) *FlowGraphArc {
-	a := new(FlowGraphArc)
+func NewArc(srcID, dstID uint64, srcNode, dstNode *Node) *Arc {
+	a := new(Arc)
 	a.src = srcID
 	a.dst = dstID
 	a.srcNode = srcNode

--- a/scheduling/flow/flowmanager/graph_change_manager.go
+++ b/scheduling/flow/flowmanager/graph_change_manager.go
@@ -12,53 +12,52 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The FlowGraphChangeManager bridges FlowGraphManager and FlowGraph. Every
-// graph change done by the FlowGraphManager should be conducted via
+package flowmanager
+
+import (
+	"github.com/coreos/ksched/scheduling/flow/dimacs"
+	"github.com/coreos/ksched/scheduling/flow/flowgraph"
+)
+
+// The GraphChangeManager bridges GraphManager and Graph. Every
+// graph change done by the GraphManager should be conducted via
 // FlowGraphChangeManager's methods.
 // The class stores all the changes conducted in-between two scheduling rounds.
 // Moreover, FlowGraphChangeManager applies various algorithms to reduce
 // the number of changes (e.g., merges idempotent changes, removes superfluous
 // changes).
-
-package flow
-
-import (
-	"github.com/coreos/ksched/scheduling/flow/cluster"
-	"github.com/coreos/ksched/scheduling/flow/dimacs"
-)
-
-type ChangeManager interface {
-	AddArcNew(src, dst *cluster.FlowGraphNode,
+type GraphChangeManager interface {
+	AddArcNew(src, dst *flowgraph.Node,
 		capLowerBound, capUpperBound uint64,
 		cost int64,
-		arcType cluster.FlowArcType,
+		arcType flowgraph.ArcType,
 		changeType dimacs.ChangeType,
-		comment string) *cluster.FlowGraphArc
+		comment string) *flowgraph.Arc
 
 	AddArcExisting(srcNodeID, dstNodeID, capLowerBound, capUpperBound uint64,
 		cost int64,
-		arcType cluster.FlowArcType,
+		arcType flowgraph.ArcType,
 		changeType dimacs.ChangeType,
-		comment string) *cluster.FlowGraphArc
+		comment string) *flowgraph.Arc
 
-	AddNode(nodeType cluster.FlowNodeType,
+	AddNode(nodeType flowgraph.NodeType,
 		excess int64,
 		changeType dimacs.ChangeType,
-		comment string) *cluster.FlowGraphNode
+		comment string) *flowgraph.Node
 
-	ChangeArc(arc cluster.FlowGraphArc, capLowerBound uint64,
+	ChangeArc(arc flowgraph.Arc, capLowerBound uint64,
 		capUpperBound uint64, cost int64,
 		changeType dimacs.ChangeType, comment string)
 
-	ChangeArcCapacity(arc cluster.FlowGraphArc, capacity uint64,
+	ChangeArcCapacity(arc flowgraph.Arc, capacity uint64,
 		changeType dimacs.ChangeType, comment string)
 
-	ChangeArcCost(arc cluster.FlowGraphArc, cost int64,
+	ChangeArcCost(arc flowgraph.Arc, cost int64,
 		changeType dimacs.ChangeType, comment string)
 
-	DeleteArc(arc cluster.FlowGraphArc, changeType dimacs.ChangeType, comment string)
+	DeleteArc(arc flowgraph.Arc, changeType dimacs.ChangeType, comment string)
 
-	DeleteNode(arc cluster.FlowGraphNode, changeType dimacs.ChangeType, comment string)
+	DeleteNode(arc flowgraph.Node, changeType dimacs.ChangeType, comment string)
 
 	GetGraphChanges() []*dimacs.Change
 
@@ -66,68 +65,68 @@ type ChangeManager interface {
 
 	ResetChanges()
 
-	CheckNodeType(nodeID uint64, typ cluster.FlowNodeType) bool
+	CheckNodeType(nodeID uint64, typ flowgraph.NodeType) bool
 
 	// FlowGraph getter: Returns flow graph instance for this manager
-	FlowGraph() *cluster.FlowGraph
+	Graph() *flowgraph.Graph
 	// Node getter
-	Node(nodeID uint64) *cluster.FlowGraphNode
+	Node(nodeID uint64) *flowgraph.Node
 }
 
 // The change manager that should implement the ChangeMangerInterface
 type changeManager struct {
-	flowGraph *cluster.FlowGraph
+	flowGraph *flowgraph.Graph
 	// Vector storing the graph changes occured since the last scheduling round.
 	graphChanges []*dimacs.Change
 	dimacsStats  *dimacs.ChangeStats
 }
 
 // Public Interface functions
-func (cm *changeManager) AddArcNew(src, dst *cluster.FlowGraphNode,
+func (cm *changeManager) AddArcNew(src, dst *flowgraph.Node,
 	capLowerBound, capUpperBound uint64,
 	cost int64,
-	arcType cluster.FlowArcType,
+	arcType flowgraph.ArcType,
 	changeType dimacs.ChangeType,
-	comment string) *cluster.FlowGraphArc {
+	comment string) *flowgraph.Arc {
 	return nil
 }
 
 func (cm *changeManager) AddArcExisting(srcNodeID, dstNodeID, capLowerBound, capUpperBound uint64,
 	cost int64,
-	arcType cluster.FlowArcType,
+	arcType flowgraph.ArcType,
 	changeType dimacs.ChangeType,
-	comment string) *cluster.FlowGraphArc {
+	comment string) *flowgraph.Arc {
 	return nil
 }
 
-func (cm *changeManager) AddNode(nodeType cluster.FlowNodeType,
+func (cm *changeManager) AddNode(nodeType flowgraph.NodeType,
 	excess int64,
 	changeType dimacs.ChangeType,
-	comment string) *cluster.FlowGraphNode {
+	comment string) *flowgraph.Node {
 	return nil
 }
 
-func (cm *changeManager) ChangeArc(arc cluster.FlowGraphArc, capLowerBound uint64,
+func (cm *changeManager) ChangeArc(arc flowgraph.Arc, capLowerBound uint64,
 	capUpperBound uint64, cost int64,
 	changeType dimacs.ChangeType, comment string) {
 
 }
 
-func (cm *changeManager) ChangeArcCapacity(arc cluster.FlowGraphArc, capacity uint64,
+func (cm *changeManager) ChangeArcCapacity(arc flowgraph.Arc, capacity uint64,
 	changeType dimacs.ChangeType, comment string) {
 
 }
 
-func (cm *changeManager) ChangeArcCost(arc cluster.FlowGraphArc, cost int64,
+func (cm *changeManager) ChangeArcCost(arc flowgraph.Arc, cost int64,
 	changeType dimacs.ChangeType, comment string) {
 
 }
 
-func (cm *changeManager) DeleteArc(arc cluster.FlowGraphArc, changeType dimacs.ChangeType, comment string) {
+func (cm *changeManager) DeleteArc(arc flowgraph.Arc, changeType dimacs.ChangeType, comment string) {
 
 }
 
-func (cm *changeManager) DeleteNode(arc cluster.FlowGraphNode, changeType dimacs.ChangeType, comment string) {
+func (cm *changeManager) DeleteNode(arc flowgraph.Node, changeType dimacs.ChangeType, comment string) {
 
 }
 
@@ -143,15 +142,15 @@ func (cm *changeManager) ResetChanges() {
 
 }
 
-func (cm *changeManager) CheckNodeType(nodeID uint64, typ cluster.FlowNodeType) bool {
+func (cm *changeManager) CheckNodeType(nodeID uint64, typ flowgraph.NodeType) bool {
 	return false
 }
 
-func (cm *changeManager) FlowGraph() *cluster.FlowGraph {
+func (cm *changeManager) Graph() *flowgraph.Graph {
 	return nil
 }
 
-func (cm *changeManager) Node(nodeID uint64) *cluster.FlowGraphNode {
+func (cm *changeManager) Node(nodeID uint64) *flowgraph.Node {
 	return nil
 }
 
@@ -173,7 +172,7 @@ func (cm *changeManager) mergeChangesToSameArc() {
 // it updates the existing change.
 func (cm *changeManager) mergeChangesToSameArcHelper(
 	srcID, dstID, capLowerBound, capUpperBound uint64,
-	cost int64, typ cluster.FlowArcType,
+	cost int64, typ flowgraph.ArcType,
 	change *dimacs.Change, newGraphChanges []*dimacs.Change,
 	arcsSrcChanges map[uint64]map[uint64]*dimacs.Change,
 	arcsDstChanges map[uint64]map[uint64]*dimacs.Change) {

--- a/scheduling/flow/flowmanager/graph_manager.go
+++ b/scheduling/flow/flowmanager/graph_manager.go
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The flow graph manager which uses the changemanager to change the graph
+package flowmanager
 
-package flow
-
-type ManagerInterface interface {
+// NOTE: GraphManager uses GraphChangeManager to change the graph.
+type GraphManager interface {
 }
 
-type Manager struct {
+type graphManager struct {
 }


### PR DESCRIPTION
Changes:
- move all graph types into flowgraph/. Change naming to excluding "FlowGraph" prefix.
- move manager types into flowmanager/.
