### PR TITLE
[WIP] flow_scheduler/interface

### DIFF
--- a/scheduling/flow/flowscheduler/interface.go
+++ b/scheduling/flow/flowscheduler/interface.go
@@ -102,7 +102,7 @@ type Scheduler interface {
 	HandleTaskFailure(td *pb.TaskDescriptor)
 
 	// KillRunningTask kills a running task.
-	// @param task_id the id of the task to kill
+	// task_id: the id of the task to kill
 	// NOTE: modified to not include kill message
 	KillRunningTask(taskID types.TaskID)
 


### PR DESCRIPTION
Porting the interface used by event_driven_scheduler(parent) and flow_scheduler(base class) so we can have place holders on the methods and fields needed to port the RunSchedulingIteration function in flow_scheduler.
