### PR TITLE
cmd, k8s: new options for running pods with a specified scheduler name

### DIFF
--- a/cmd/k8sscheduler/scheduler.go
+++ b/cmd/k8sscheduler/scheduler.go
@@ -26,6 +26,7 @@ var (
 	nodeBatchTimeout int
 	podChanSize      int
 	fakeMachines     bool
+	schedulerName    string
 )
 
 func init() {
@@ -37,6 +38,7 @@ func init() {
 	// Fake the machine topology, only useful for testing when the API server has no nodes
 	flag.BoolVar(&fakeMachines, "fakeMachines", false, "fake the machine topology if running without a real cluster")
 	flag.IntVar(&numMachines, "nm", 2, "number of machines, only needed if faking the resource topology")
+	flag.StringVar(&schedulerName, "scheduler", "default-scheduler", "a name of this scheduler")
 
 	flag.Parse()
 }
@@ -88,7 +90,7 @@ func New(client *k8sclient.Client, maxTasksPerPu int) *k8scheduler {
 
 func main() {
 	// Initialize the kubernetes client
-	config := k8sclient.Config{Addr: address}
+	config := k8sclient.Config{Addr: address, SchedulerName: schedulerName}
 	client, err := k8sclient.New(config, podChanSize)
 	if err != nil {
 		panic(err)

--- a/k8s/k8sclient/client.go
+++ b/k8s/k8sclient/client.go
@@ -16,8 +16,13 @@ import (
 	"k8s.io/kubernetes/pkg/watch"
 )
 
+const (
+	SchedulerAnnotationKey = "scheduler.alpha.kubernetes.io/name"
+)
+
 type Config struct {
-	Addr string
+	Addr          string
+	SchedulerName string
 }
 
 type Client struct {
@@ -59,6 +64,10 @@ func New(cfg Config, podChanSize int) (*Client, error) {
 	informer.AddEventHandler(framework.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*api.Pod)
+			if pod.Annotations[SchedulerAnnotationKey] != cfg.SchedulerName {
+				return
+			}
+
 			ourPod := &k8stype.Pod{
 				ID: makePodID(pod.Namespace, pod.Name),
 			}


### PR DESCRIPTION
Currently k8sscheduler tries to schedule every pod generated in a k8s
cluster. However, because of this behavior k8sscheduler conflicts with
the default scheduler. So this commit adds a new option -scheduler to
k8sscheduler: the value passed with the option is used as the field
scheduler.alpha.kubernetes.io/name of Pods' annotations. k8sscheduler
only schedules pods that have the name in the field.

This commit also adds a new option -scheduler to the podgen
command. If the command is specified, podgen creates pods with
specifying the scheduler with the annotations field.