### PR TITLE
RFC: cmd, k8s: more fine grained timers for getting unscheduled pods

### DIFF
--- a/cmd/k8sscheduler/scheduler.go
+++ b/cmd/k8sscheduler/scheduler.go
@@ -19,19 +19,21 @@ import (
 )
 
 var (
-	numMachines      int
-	address          string
-	maxTasksPerPu    int
-	batchTimeout     int
-	nodeBatchTimeout int
-	podChanSize      int
-	fakeMachines     bool
+	numMachines        int
+	address            string
+	maxTasksPerPu      int
+	batchTimeout       int
+	entireBatchTimeout int
+	nodeBatchTimeout   int
+	podChanSize        int
+	fakeMachines       bool
 )
 
 func init() {
 	flag.StringVar(&address, "addr", "127.0.0.1:8080", "APIServer addr")
 	flag.IntVar(&maxTasksPerPu, "mt", 1000, "maximum number of tasks per machine")
-	flag.IntVar(&batchTimeout, "pbt", 2, "pods batch timeout in seconds")
+	flag.IntVar(&batchTimeout, "pbt", 2000, "pods batch timeout in milliseconds")
+	flag.IntVar(&entireBatchTimeout, "epbt", 2000, "batch timeout in milliseconds for entire process of obtaining unscheduled pods")
 	flag.IntVar(&nodeBatchTimeout, "nbt", 2, "node batch timeout in seconds")
 	flag.IntVar(&podChanSize, "pcs", 5000, "pod channel size in client's pod informer")
 	// Fake the machine topology, only useful for testing when the API server has no nodes
@@ -120,7 +122,7 @@ func (ks *k8scheduler) Run(client *k8sclient.Client) {
 	// Loop: Read pods, Schedule, and Assign Bindings
 	for {
 		// Process batch of new Pod updates
-		newPods := client.GetPodBatch(time.Duration(batchTimeout) * time.Second)
+		newPods := client.GetPodBatch(time.Duration(batchTimeout) * time.Millisecond, time.Duration(entireBatchTimeout) * time.Millisecond)
 
 		// No need to schedule or assign task bindings if no new pods
 		if len(newPods) == 0 {

--- a/k8s/k8sclient/client.go
+++ b/k8s/k8sclient/client.go
@@ -141,7 +141,7 @@ func (c *Client) AssignBinding(bindings []*k8stype.Binding) error {
 // Returns a batch of pods or blocks until there is at least on pod creation call back
 // The timeout specifies how long to wait for another pod on the pod channel before returning
 // the batch of pods that need to be scheduled
-func (c *Client) GetPodBatch(timeout time.Duration) []*k8stype.Pod {
+func (c *Client) GetPodBatch(timeout, entireTimeout time.Duration) []*k8stype.Pod {
 	batchedPods := make([]*k8stype.Pod, 0)
 
 	fmt.Printf("Waiting for a pod scheduling request\n")
@@ -155,6 +155,13 @@ func (c *Client) GetPodBatch(timeout time.Duration) []*k8stype.Pod {
 	done := make(chan bool)
 	go func() {
 		<-timer.C
+		done <- true
+	}()
+
+	// Set timer for entire timeout of getting unscheduled pods
+	entireTimer := time.NewTimer(entireTimeout) // never reset like timer
+	go func() {
+		<-entireTimer.C
 		done <- true
 	}()
 


### PR DESCRIPTION
Firmament is a scheduler that target sub-second placement latency, so
a unit of second for GetPodBatch() is too coarse grain. In addition,
an event of newly arrival pod can extend the timeout. For stopping
waiting new pods and making scheduling decision for low latency, this
commit adds a new option -ebpt to k8sscheduler. Even if new pods are
ready for scheduling, GetPodBatch() returns if the time exceeds the
timeout specified with the option.