### PR TITLE
scheduling: find a binary of Flowlessly from PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can test the scheduler without the real cluster by only having the `kube-api
 
 You will need to have the same environment set up as is for the ksched image described by `build/Dockerfile`. Use that as a guide for your setup.
 
-* Setup the [Flowlessly](https://github.com/ICGog/Flowlessly) solver binary in the correct location: `/usr/local/bin/flowlessly/`.
+* Setup the [Flowlessly](https://github.com/ICGog/Flowlessly) solver binary in your `$PATH`.
 * Setup the Kubernetes(v1.3) source at the following location in your go workspace: `$GOPATH/src/k8s.io`
 * Get the ksched source: `go get github.com/coreos/ksched` (or from the mirror repo `github.com/hasbro17/ksched-mirror`)
 * Generate the proto files by running `proto/genproto.sh` 

--- a/scheduling/flow/placement/solver.go
+++ b/scheduling/flow/placement/solver.go
@@ -28,10 +28,20 @@ import (
 )
 
 var (
-	FlowlesslyBinary    = "/usr/local/bin/flowlessly/flow_scheduler"
+	flowlesslyBinary    = "flow_scheduler"
+	flowlesslyPath      string
 	FlowlesslyAlgorithm = "successive_shortest_path"
 	Incremental         = true
 )
+
+func init() {
+	path, err := exec.LookPath(flowlesslyBinary)
+	if err != nil {
+		fmt.Printf("Finding the binary of Flowlessly (flow_scheduler) failed: %s\n", err)
+		os.Exit(1)
+	}
+	flowlesslyPath = path
+}
 
 type Solver interface {
 	Solve() flowmanager.TaskMapping
@@ -276,5 +286,5 @@ func (fs *flowlesslySolver) getBinConfig() (string, []string) {
 		args = append(args, "--daemon=false")
 	}
 
-	return FlowlesslyBinary, args
+	return flowlesslyPath, args
 }


### PR DESCRIPTION
Currently k8sscheduler causes an error if it cannot find a binary of
Flowlessly (flow_scheduler) when it trires to schedule pods. Causing
the error immediately direct after execution of the command would be a
little bit friendly. This commit also let k8sscheduler search the
binary from env var PATH instead of the fixed path.